### PR TITLE
Inherited Supervisor & Registry Queue Ids

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -44,14 +44,12 @@ impl ProcessManager for SystemProcessManager {
             page_allocator(),
             id,
             Properties {
-                supervisor: info
+                supervisor_queue: info
                     .supervisor
-                    .and_then(|sid| self.process_for_id(sid))
-                    .or_else(|| parent.as_ref().and_then(|p| p.props.supervisor.clone())),
-                registry: info
+                    .or_else(|| parent.as_ref().and_then(|p| p.props.supervisor_queue)),
+                registry_queue: info
                     .registry
-                    .and_then(|sid| self.process_for_id(sid))
-                    .or_else(|| parent.as_ref().and_then(|p| p.props.registry.clone())),
+                    .or_else(|| parent.as_ref().and_then(|p| p.props.registry_queue)),
                 privilege: info.privilege_level,
             },
             unsafe { core::slice::from_raw_parts(info.sections, info.num_sections) },
@@ -79,7 +77,7 @@ impl ProcessManager for SystemProcessManager {
             }
         }
 
-        if process.props.supervisor.is_none() {
+        if process.props.supervisor_queue.is_none() {
             // the root process has exited
             qemu_exit::AArch64::new().exit(match reason.tag {
                 kernel_api::ExitReasonTag::User => reason.user_code,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -48,6 +48,10 @@ impl ProcessManager for SystemProcessManager {
                     .supervisor
                     .and_then(|sid| self.process_for_id(sid))
                     .or_else(|| parent.as_ref().and_then(|p| p.props.supervisor.clone())),
+                registry: info
+                    .registry
+                    .and_then(|sid| self.process_for_id(sid))
+                    .or_else(|| parent.as_ref().and_then(|p| p.props.registry.clone())),
                 privilege: info.privilege_level,
             },
             unsafe { core::slice::from_raw_parts(info.sections, info.num_sections) },

--- a/kernel_api/src/lib.rs
+++ b/kernel_api/src/lib.rs
@@ -197,6 +197,8 @@ pub struct ProcessCreateInfo {
     pub sections: *const ImageSection,
     /// The new process' supervisor, or None to inherit.
     pub supervisor: Option<ProcessId>,
+    /// The new process' registry, or None to inherit.
+    pub registry: Option<ProcessId>,
     /// The new process' privilege level (must be less than or equal to the current privilege level).
     pub privilege_level: PrivilegeLevel,
     /// Whether to notify this process via a message when the spawned process exits.

--- a/kernel_api/src/lib.rs
+++ b/kernel_api/src/lib.rs
@@ -195,10 +195,10 @@ pub struct ProcessCreateInfo {
     pub num_sections: usize,
     /// The process image sections that will be loaded into the new process.
     pub sections: *const ImageSection,
-    /// The new process' supervisor, or None to inherit.
-    pub supervisor: Option<ProcessId>,
-    /// The new process' registry, or None to inherit.
-    pub registry: Option<ProcessId>,
+    /// The new process' supervisor queue, or None to inherit.
+    pub supervisor: Option<QueueId>,
+    /// The new process' registry queue, or None to inherit.
+    pub registry: Option<QueueId>,
     /// The new process' privilege level (must be less than or equal to the current privilege level).
     pub privilege_level: PrivilegeLevel,
     /// Whether to notify this process via a message when the spawned process exits.

--- a/kernel_core/src/init.rs
+++ b/kernel_core/src/init.rs
@@ -104,6 +104,7 @@ pub fn spawn_init_process(
         num_sections: sections.len(),
         sections: sections.as_ptr(),
         supervisor: None,
+        registry: None,
         privilege_level: PrivilegeLevel::Driver,
         notify_on_exit: false,
         inbox_size: 256,

--- a/kernel_core/src/process/mod.rs
+++ b/kernel_core/src/process/mod.rs
@@ -94,10 +94,16 @@ unsafe fn copy_image_section_data_to_process_memory(
 
 /// Properties describing a process
 pub struct Properties {
-    /// The supervisor process for this process.
+    /// The assigned supervisor process for this process.
     ///
     /// None means that this process is the root process (of which there should only be one).
     pub supervisor: Option<Arc<Process>>,
+
+    /// The assigned registry process for this process.
+    ///
+    /// None means that this process is the root process (of which there should only be one).
+    pub registry: Option<Arc<Process>>,
+
     /// Level of privilege this process has.
     pub privilege: PrivilegeLevel,
 }
@@ -733,6 +739,7 @@ pub mod tests {
             ProcessId::new(1).unwrap(),
             Properties {
                 supervisor: None,
+                registry: None,
                 privilege: kernel_api::PrivilegeLevel::Driver,
             },
             ThreadId::new(1).unwrap(),
@@ -748,6 +755,7 @@ pub mod tests {
             ProcessId::new(1).unwrap(),
             Properties {
                 supervisor: None,
+                registry: None,
                 privilege: kernel_api::PrivilegeLevel::Driver,
             },
             ThreadId::new(1).unwrap(),

--- a/kernel_core/src/process/mod.rs
+++ b/kernel_core/src/process/mod.rs
@@ -94,15 +94,15 @@ unsafe fn copy_image_section_data_to_process_memory(
 
 /// Properties describing a process
 pub struct Properties {
-    /// The assigned supervisor process for this process.
+    /// The inherited queue ID for communicating with this process' assigned supervisor.
     ///
     /// None means that this process is the root process (of which there should only be one).
-    pub supervisor: Option<Arc<Process>>,
+    pub supervisor_queue: Option<QueueId>,
 
-    /// The assigned registry process for this process.
+    /// The inherited queue ID for communicating with this process' assigned registry.
     ///
     /// None means that this process is the root process (of which there should only be one).
-    pub registry: Option<Arc<Process>>,
+    pub registry_queue: Option<QueueId>,
 
     /// Level of privilege this process has.
     pub privilege: PrivilegeLevel,
@@ -738,8 +738,8 @@ pub mod tests {
         let proc = create_test_process(
             ProcessId::new(1).unwrap(),
             Properties {
-                supervisor: None,
-                registry: None,
+                supervisor_queue: None,
+                registry_queue: None,
                 privilege: kernel_api::PrivilegeLevel::Driver,
             },
             ThreadId::new(1).unwrap(),
@@ -754,8 +754,8 @@ pub mod tests {
         let proc = create_test_process(
             ProcessId::new(1).unwrap(),
             Properties {
-                supervisor: None,
-                registry: None,
+                supervisor_queue: None,
+                registry_queue: None,
                 privilege: kernel_api::PrivilegeLevel::Driver,
             },
             ThreadId::new(1).unwrap(),

--- a/kernel_core/src/process/system_calls/mod.rs
+++ b/kernel_core/src/process/system_calls/mod.rs
@@ -301,14 +301,16 @@ impl<'pa, 'm, PA: PageAllocator, PM: ProcessManager, TM: ThreadManager, QM: Queu
             "reading value {value_to_read:?} for thread {}",
             current_thread.id
         );
+        let parent = current_thread.parent.as_ref();
         match value_to_read {
-            EnvironmentValue::CurrentProcessId => current_thread
-                .parent
-                .as_ref()
-                .map_or(0, |p| p.id.get() as usize),
+            EnvironmentValue::CurrentProcessId => parent.map_or(0, |p| p.id.get() as usize),
             EnvironmentValue::CurrentThreadId => current_thread.id.get() as usize,
-            EnvironmentValue::CurrentSupervisorQueueId => todo!(),
-            EnvironmentValue::CurrentRegistryQueueId => todo!(),
+            EnvironmentValue::CurrentSupervisorQueueId => {
+                parent.map_or(0, |p| p.props.supervisor_queue.unwrap().get() as usize)
+            }
+            EnvironmentValue::CurrentRegistryQueueId => {
+                parent.map_or(0, |p| p.props.registry_queue.unwrap().get() as usize)
+            }
             EnvironmentValue::PageSizeInBytes => self.page_allocator.page_size().into(),
         }
     }

--- a/kernel_core/src/process/system_calls/mod.rs
+++ b/kernel_core/src/process/system_calls/mod.rs
@@ -301,16 +301,21 @@ impl<'pa, 'm, PA: PageAllocator, PM: ProcessManager, TM: ThreadManager, QM: Queu
             "reading value {value_to_read:?} for thread {}",
             current_thread.id
         );
-        let parent = current_thread.parent.as_ref();
+        let current_proc = current_thread
+            .parent
+            .as_ref()
+            .expect("kernel threads don't make syscalls");
         match value_to_read {
-            EnvironmentValue::CurrentProcessId => parent.map_or(0, |p| p.id.get() as usize),
+            EnvironmentValue::CurrentProcessId => current_proc.id.get() as usize,
             EnvironmentValue::CurrentThreadId => current_thread.id.get() as usize,
-            EnvironmentValue::CurrentSupervisorQueueId => {
-                parent.map_or(0, |p| p.props.supervisor_queue.unwrap().get() as usize)
-            }
-            EnvironmentValue::CurrentRegistryQueueId => {
-                parent.map_or(0, |p| p.props.registry_queue.unwrap().get() as usize)
-            }
+            EnvironmentValue::CurrentSupervisorQueueId => current_proc
+                .props
+                .supervisor_queue
+                .map_or(0, |id| id.get() as usize),
+            EnvironmentValue::CurrentRegistryQueueId => current_proc
+                .props
+                .registry_queue
+                .map_or(0, |id| id.get() as usize),
             EnvironmentValue::PageSizeInBytes => self.page_allocator.page_size().into(),
         }
     }

--- a/kernel_core/src/process/system_calls/tests.rs
+++ b/kernel_core/src/process/system_calls/tests.rs
@@ -138,8 +138,8 @@ fn exit_thread_exits_process() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(7).unwrap(),
         crate::process::Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(8).unwrap(),
@@ -196,8 +196,8 @@ fn normal_spawn_thread() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(7).unwrap(),
         crate::process::Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(8).unwrap(),
@@ -258,8 +258,8 @@ fn normal_send() {
     let sender_proc = crate::process::tests::create_test_process(
         ProcessId::new(7).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -268,8 +268,8 @@ fn normal_send() {
     let receiver_proc = crate::process::tests::create_test_process(
         ProcessId::new(8).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(81).unwrap(),
@@ -367,8 +367,8 @@ fn normal_receive_would_block() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(7).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -409,8 +409,8 @@ fn normal_receive_block() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(7).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -465,8 +465,8 @@ fn normal_receive_immediate() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(7).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -537,8 +537,8 @@ fn normal_spawn_process() {
     let parent_proc = crate::process::tests::create_test_process(
         ProcessId::new(10).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(11).unwrap(),
@@ -567,8 +567,8 @@ fn normal_spawn_process() {
     let new_proc = crate::process::tests::create_test_process(
         new_proc_id,
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(21).unwrap(),
@@ -636,8 +636,8 @@ fn normal_kill_process() {
     let parent_proc = crate::process::tests::create_test_process(
         ProcessId::new(30).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(31).unwrap(),
@@ -648,8 +648,8 @@ fn normal_kill_process() {
     let target_proc = crate::process::tests::create_test_process(
         ProcessId::new(40).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         target_thread_id,
@@ -695,8 +695,8 @@ fn normal_allocate_heap_pages() {
     let parent_proc = crate::process::tests::create_test_process(
         ProcessId::new(50).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(51).unwrap(),
@@ -736,8 +736,8 @@ fn normal_free_heap_pages() {
     let parent_proc = crate::process::tests::create_test_process(
         ProcessId::new(60).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(61).unwrap(),
@@ -785,8 +785,8 @@ fn normal_transfer_to_shared_buffer() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(70).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(71).unwrap(),
@@ -846,8 +846,8 @@ fn normal_transfer_from_shared_buffer() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(80).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(81).unwrap(),
@@ -906,8 +906,8 @@ fn normal_free_message_no_buffers() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(100).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(101).unwrap(),
@@ -944,8 +944,8 @@ fn normal_free_shared_buffers() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(110).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(111).unwrap(),
@@ -992,8 +992,8 @@ fn normal_exit_notification_subscription_process() {
     let current_proc = crate::process::tests::create_test_process(
         ProcessId::new(120).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(121).unwrap(),
@@ -1009,8 +1009,8 @@ fn normal_exit_notification_subscription_process() {
     let target_proc = crate::process::tests::create_test_process(
         ProcessId::new(130).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(131).unwrap(),
@@ -1057,8 +1057,8 @@ fn normal_exit_notification_subscription_thread() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(140).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(141).unwrap(),
@@ -1114,8 +1114,8 @@ fn create_message_queue_success() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(200).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(201).unwrap(),
@@ -1159,8 +1159,8 @@ fn create_message_queue_bad_ptr() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(202).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(203).unwrap(),
@@ -1194,8 +1194,8 @@ fn free_message_queue_success() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(210).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(211).unwrap(),
@@ -1243,8 +1243,8 @@ fn free_message_queue_not_found() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(212).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(213).unwrap(),
@@ -1281,8 +1281,8 @@ fn free_message_with_buffers_and_flag() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(220).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(221).unwrap(),
@@ -1347,8 +1347,8 @@ fn write_log_success() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(230).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(231).unwrap(),
@@ -1385,8 +1385,8 @@ fn write_log_invalid_level() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(232).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(233).unwrap(),
@@ -1424,8 +1424,8 @@ fn exit_notification_unsubscribe() {
     let current_proc = crate::process::tests::create_test_process(
         ProcessId::new(240).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(241).unwrap(),
@@ -1477,8 +1477,8 @@ fn exit_notification_invalid_flags() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(242).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(243).unwrap(),
@@ -1519,8 +1519,8 @@ fn transfer_to_shared_buffer_out_of_bounds() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(250).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(251).unwrap(),
@@ -1580,8 +1580,8 @@ fn transfer_from_shared_buffer_out_of_bounds() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(300).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(301).unwrap(),
@@ -1642,8 +1642,8 @@ fn transfer_to_shared_buffer_insufficient_permissions() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(302).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(303).unwrap(),
@@ -1704,8 +1704,8 @@ fn transfer_from_shared_buffer_insufficient_permissions() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(304).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(305).unwrap(),
@@ -1766,8 +1766,8 @@ fn allocate_heap_pages_zero_size_invalid_length() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(306).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(307).unwrap(),
@@ -1802,8 +1802,8 @@ fn free_heap_pages_zero_size_invalid_length() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(308).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(309).unwrap(),
@@ -1854,8 +1854,8 @@ fn kill_process_not_found() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(310).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(311).unwrap(),
@@ -1892,8 +1892,8 @@ fn send_zero_length_message_invalid_length() {
     let sender = crate::process::tests::create_test_process(
         ProcessId::new(312).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(313).unwrap(),
@@ -1902,8 +1902,8 @@ fn send_zero_length_message_invalid_length() {
     let receiver = crate::process::tests::create_test_process(
         ProcessId::new(314).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(315).unwrap(),
@@ -1950,8 +1950,8 @@ fn free_shared_buffers_not_found() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(316).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(317).unwrap(),
@@ -2002,8 +2002,8 @@ fn create_message_queue_out_of_handles() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(318).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(319).unwrap(),
@@ -2045,8 +2045,8 @@ fn read_env_value_page_size() {
     let proc = crate::process::tests::create_test_process(
         ProcessId::new(320).unwrap(),
         Properties {
-            supervisor: None,
-            registry: None,
+            supervisor_queue: None,
+            registry_queue: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(321).unwrap(),

--- a/kernel_core/src/process/system_calls/tests.rs
+++ b/kernel_core/src/process/system_calls/tests.rs
@@ -139,6 +139,7 @@ fn exit_thread_exits_process() {
         ProcessId::new(7).unwrap(),
         crate::process::Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(8).unwrap(),
@@ -196,6 +197,7 @@ fn normal_spawn_thread() {
         ProcessId::new(7).unwrap(),
         crate::process::Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(8).unwrap(),
@@ -257,6 +259,7 @@ fn normal_send() {
         ProcessId::new(7).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -266,6 +269,7 @@ fn normal_send() {
         ProcessId::new(8).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(81).unwrap(),
@@ -364,6 +368,7 @@ fn normal_receive_would_block() {
         ProcessId::new(7).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -405,6 +410,7 @@ fn normal_receive_block() {
         ProcessId::new(7).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -460,6 +466,7 @@ fn normal_receive_immediate() {
         ProcessId::new(7).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(80).unwrap(),
@@ -531,6 +538,7 @@ fn normal_spawn_process() {
         ProcessId::new(10).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(11).unwrap(),
@@ -542,6 +550,7 @@ fn normal_spawn_process() {
         num_sections: 0,
         sections: core::ptr::null(),
         supervisor: None,
+        registry: None,
         privilege_level: kernel_api::PrivilegeLevel::Unprivileged,
         notify_on_exit: false,
         inbox_size: 0,
@@ -559,6 +568,7 @@ fn normal_spawn_process() {
         new_proc_id,
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(21).unwrap(),
@@ -627,6 +637,7 @@ fn normal_kill_process() {
         ProcessId::new(30).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(31).unwrap(),
@@ -638,6 +649,7 @@ fn normal_kill_process() {
         ProcessId::new(40).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         target_thread_id,
@@ -684,6 +696,7 @@ fn normal_allocate_heap_pages() {
         ProcessId::new(50).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(51).unwrap(),
@@ -724,6 +737,7 @@ fn normal_free_heap_pages() {
         ProcessId::new(60).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(61).unwrap(),
@@ -772,6 +786,7 @@ fn normal_transfer_to_shared_buffer() {
         ProcessId::new(70).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(71).unwrap(),
@@ -832,6 +847,7 @@ fn normal_transfer_from_shared_buffer() {
         ProcessId::new(80).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(81).unwrap(),
@@ -891,6 +907,7 @@ fn normal_free_message_no_buffers() {
         ProcessId::new(100).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(101).unwrap(),
@@ -928,6 +945,7 @@ fn normal_free_shared_buffers() {
         ProcessId::new(110).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(111).unwrap(),
@@ -975,6 +993,7 @@ fn normal_exit_notification_subscription_process() {
         ProcessId::new(120).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(121).unwrap(),
@@ -991,6 +1010,7 @@ fn normal_exit_notification_subscription_process() {
         ProcessId::new(130).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(131).unwrap(),
@@ -1038,6 +1058,7 @@ fn normal_exit_notification_subscription_thread() {
         ProcessId::new(140).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(141).unwrap(),
@@ -1094,6 +1115,7 @@ fn create_message_queue_success() {
         ProcessId::new(200).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(201).unwrap(),
@@ -1138,6 +1160,7 @@ fn create_message_queue_bad_ptr() {
         ProcessId::new(202).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(203).unwrap(),
@@ -1172,6 +1195,7 @@ fn free_message_queue_success() {
         ProcessId::new(210).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(211).unwrap(),
@@ -1220,6 +1244,7 @@ fn free_message_queue_not_found() {
         ProcessId::new(212).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(213).unwrap(),
@@ -1257,6 +1282,7 @@ fn free_message_with_buffers_and_flag() {
         ProcessId::new(220).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(221).unwrap(),
@@ -1322,6 +1348,7 @@ fn write_log_success() {
         ProcessId::new(230).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(231).unwrap(),
@@ -1359,6 +1386,7 @@ fn write_log_invalid_level() {
         ProcessId::new(232).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(233).unwrap(),
@@ -1397,6 +1425,7 @@ fn exit_notification_unsubscribe() {
         ProcessId::new(240).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(241).unwrap(),
@@ -1449,6 +1478,7 @@ fn exit_notification_invalid_flags() {
         ProcessId::new(242).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(243).unwrap(),
@@ -1490,6 +1520,7 @@ fn transfer_to_shared_buffer_out_of_bounds() {
         ProcessId::new(250).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(251).unwrap(),
@@ -1550,6 +1581,7 @@ fn transfer_from_shared_buffer_out_of_bounds() {
         ProcessId::new(300).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(301).unwrap(),
@@ -1611,6 +1643,7 @@ fn transfer_to_shared_buffer_insufficient_permissions() {
         ProcessId::new(302).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(303).unwrap(),
@@ -1672,6 +1705,7 @@ fn transfer_from_shared_buffer_insufficient_permissions() {
         ProcessId::new(304).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(305).unwrap(),
@@ -1733,6 +1767,7 @@ fn allocate_heap_pages_zero_size_invalid_length() {
         ProcessId::new(306).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(307).unwrap(),
@@ -1768,6 +1803,7 @@ fn free_heap_pages_zero_size_invalid_length() {
         ProcessId::new(308).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(309).unwrap(),
@@ -1819,6 +1855,7 @@ fn kill_process_not_found() {
         ProcessId::new(310).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(311).unwrap(),
@@ -1856,6 +1893,7 @@ fn send_zero_length_message_invalid_length() {
         ProcessId::new(312).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(313).unwrap(),
@@ -1865,6 +1903,7 @@ fn send_zero_length_message_invalid_length() {
         ProcessId::new(314).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(315).unwrap(),
@@ -1912,6 +1951,7 @@ fn free_shared_buffers_not_found() {
         ProcessId::new(316).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(317).unwrap(),
@@ -1963,6 +2003,7 @@ fn create_message_queue_out_of_handles() {
         ProcessId::new(318).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(319).unwrap(),
@@ -2005,6 +2046,7 @@ fn read_env_value_page_size() {
         ProcessId::new(320).unwrap(),
         Properties {
             supervisor: None,
+            registry: None,
             privilege: kernel_api::PrivilegeLevel::Privileged,
         },
         ThreadId::new(321).unwrap(),

--- a/services/check-syscalls/src/read_env_value.rs
+++ b/services/check-syscalls/src/read_env_value.rs
@@ -23,7 +23,10 @@ fn invalid_env_value() {
 
 fn supervisor_id() {
     // we are the root process
-    assert_eq!(read_env_value(EnvironmentValue::CurrentSupervisorQueueId), 0);
+    assert_eq!(
+        read_env_value(EnvironmentValue::CurrentSupervisorQueueId),
+        0
+    );
 }
 
 fn registry_id() {
@@ -33,5 +36,12 @@ fn registry_id() {
 
 pub const TESTS: (&str, &[&dyn Testable]) = (
     "read_env_value",
-    &[&process_id, &thread_id, &page_size, &invalid_env_value],
+    &[
+        &process_id,
+        &thread_id,
+        &page_size,
+        &invalid_env_value,
+        &supervisor_id,
+        &registry_id,
+    ],
 );

--- a/services/check-syscalls/src/read_env_value.rs
+++ b/services/check-syscalls/src/read_env_value.rs
@@ -5,6 +5,7 @@ use crate::Testable;
 fn process_id() {
     assert_eq!(read_env_value(EnvironmentValue::CurrentProcessId), 1);
 }
+
 fn thread_id() {
     // this value depends on the number of processors since each processor gets an idle thread
     assert!(read_env_value(EnvironmentValue::CurrentThreadId) >= 1);
@@ -18,6 +19,16 @@ fn page_size() {
 fn invalid_env_value() {
     let bad_env_value = unsafe { core::mem::transmute::<usize, EnvironmentValue>(99usize) };
     assert_eq!(read_env_value(bad_env_value), 0);
+}
+
+fn supervisor_id() {
+    // we are the root process
+    assert_eq!(read_env_value(EnvironmentValue::CurrentSupervisorQueueId), 0);
+}
+
+fn registry_id() {
+    // we are the root process
+    assert_eq!(read_env_value(EnvironmentValue::CurrentRegistryQueueId), 0);
 }
 
 pub const TESTS: (&str, &[&dyn Testable]) = (

--- a/services/egg/src/spawn.rs
+++ b/services/egg/src/spawn.rs
@@ -86,6 +86,7 @@ pub fn spawn_root_process(
         num_sections: sections.len(),
         sections: sections.as_ptr(),
         supervisor: Some(self_pid),
+        registry: Some(self_pid),
         privilege_level: PrivilegeLevel::Driver,
         notify_on_exit: false,
         inbox_size: 256,


### PR DESCRIPTION
Make it so processes inherit an associated queue id for both a supervisor and registry. Perhaps it is a little messy like this? 