### PR TITLE
Allow exit subscriptions when spawning processes/threads

### DIFF
--- a/kernel_api/src/lib.rs
+++ b/kernel_api/src/lib.rs
@@ -128,6 +128,8 @@ pub struct ThreadCreateInfo {
     pub stack_size: usize,
     /// The user paramter that will be passed to the entry point function.
     pub user_data: usize,
+    /// An optional queue to notify with an exit message when the spawned thread exits (same as [`exit_notification_subscription`]).
+    pub notify_on_exit: Option<QueueId>,
 }
 
 /// The unique ID of a process.
@@ -201,8 +203,8 @@ pub struct ProcessCreateInfo {
     pub registry: Option<QueueId>,
     /// The new process' privilege level (must be less than or equal to the current privilege level).
     pub privilege_level: PrivilegeLevel,
-    /// Whether to notify this process via a message when the spawned process exits.
-    pub notify_on_exit: bool,
+    /// An optional queue to notify with an exit message when the spawned process exits (same as [`exit_notification_subscription`]).
+    pub notify_on_exit: Option<QueueId>,
     /// The size of this process' message inbox, in message blocks.
     pub inbox_size: usize,
 }

--- a/kernel_core/src/init.rs
+++ b/kernel_core/src/init.rs
@@ -106,7 +106,6 @@ pub fn spawn_init_process(
         supervisor: None,
         registry: None,
         privilege_level: PrivilegeLevel::Driver,
-        notify_on_exit: None,
         inbox_size: 256,
     };
     debug!("init image = {info:?}");

--- a/kernel_core/src/process/mod.rs
+++ b/kernel_core/src/process/mod.rs
@@ -81,8 +81,6 @@ pub struct ProcessCreateInfo<'a> {
     pub registry: Option<QueueId>,
     /// The new process' privilege level (must be less than or equal to the current privilege level).
     pub privilege_level: PrivilegeLevel,
-    /// An optional queue to notify with an exit message when the spawned process exits (same as [`exit_notification_subscription`]).
-    pub notify_on_exit: Option<Arc<MessageQueue>>,
     /// The size of this process' message inbox, in message blocks.
     pub inbox_size: usize,
 }

--- a/kernel_core/src/process/mod.rs
+++ b/kernel_core/src/process/mod.rs
@@ -688,54 +688,6 @@ pub enum ManagerError {
     },
 }
 
-/// A section of memory in a process image.
-#[derive(Clone)]
-pub struct ImageSection<'a> {
-    /// The base address in the process' address space. This must be page aligned.
-    pub base_address: VirtualAddress,
-    /// Offset from the base address where the `data` will be copied to. Any bytes between the
-    /// start and the offset will be zeroed.
-    pub data_offset: usize,
-    /// The total size of the section in bytes (including the `data_offset` bytes).
-    /// Any bytes past the size of `data` will be zeroed.
-    pub total_size: usize,
-    /// The data that will be copied into the section.
-    pub data: &'a [u8],
-    /// The type of section this is.
-    pub kind: ImageSectionKind,
-}
-
-impl Debug for ImageSection<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ImageSection")
-            .field("base_address", &self.base_address)
-            .field("data_offset", &self.data_offset)
-            .field("total_size", &self.total_size)
-            .field("data.len()", &self.data.len())
-            .field("kind", &self.kind)
-            .finish()
-    }
-}
-
-/// Parameters for creating a new process.
-#[derive(Clone)]
-pub struct ProcessCreateInfo<'a> {
-    /// The main entry point in the process image.
-    pub entry_point: VirtualAddress,
-    /// The process image sections that will be loaded into the new process.
-    pub sections: &'a [ImageSection<'a>],
-    /// The new process' supervisor queue, or None to inherit.
-    pub supervisor: Option<QueueId>,
-    /// The new process' registry queue, or None to inherit.
-    pub registry: Option<QueueId>,
-    /// The new process' privilege level (must be less than or equal to the current privilege level).
-    pub privilege_level: PrivilegeLevel,
-    /// An optional queue to notify with an exit message when the spawned process exits (same as [`exit_notification_subscription`]).
-    pub notify_on_exit: Option<Arc<MessageQueue>>,
-    /// The size of this process' message inbox, in message blocks.
-    pub inbox_size: usize,
-}
-
 /// An interface for managing processes.
 #[cfg_attr(test, mockall::automock)]
 pub trait ProcessManager {

--- a/kernel_core/src/process/mod.rs
+++ b/kernel_core/src/process/mod.rs
@@ -690,6 +690,54 @@ pub enum ManagerError {
     },
 }
 
+/// A section of memory in a process image.
+#[derive(Clone)]
+pub struct ImageSection<'a> {
+    /// The base address in the process' address space. This must be page aligned.
+    pub base_address: VirtualAddress,
+    /// Offset from the base address where the `data` will be copied to. Any bytes between the
+    /// start and the offset will be zeroed.
+    pub data_offset: usize,
+    /// The total size of the section in bytes (including the `data_offset` bytes).
+    /// Any bytes past the size of `data` will be zeroed.
+    pub total_size: usize,
+    /// The data that will be copied into the section.
+    pub data: &'a [u8],
+    /// The type of section this is.
+    pub kind: ImageSectionKind,
+}
+
+impl Debug for ImageSection<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ImageSection")
+            .field("base_address", &self.base_address)
+            .field("data_offset", &self.data_offset)
+            .field("total_size", &self.total_size)
+            .field("data.len()", &self.data.len())
+            .field("kind", &self.kind)
+            .finish()
+    }
+}
+
+/// Parameters for creating a new process.
+#[derive(Clone)]
+pub struct ProcessCreateInfo<'a> {
+    /// The main entry point in the process image.
+    pub entry_point: VirtualAddress,
+    /// The process image sections that will be loaded into the new process.
+    pub sections: &'a [ImageSection<'a>],
+    /// The new process' supervisor queue, or None to inherit.
+    pub supervisor: Option<QueueId>,
+    /// The new process' registry queue, or None to inherit.
+    pub registry: Option<QueueId>,
+    /// The new process' privilege level (must be less than or equal to the current privilege level).
+    pub privilege_level: PrivilegeLevel,
+    /// An optional queue to notify with an exit message when the spawned process exits (same as [`exit_notification_subscription`]).
+    pub notify_on_exit: Option<Arc<MessageQueue>>,
+    /// The size of this process' message inbox, in message blocks.
+    pub inbox_size: usize,
+}
+
 /// An interface for managing processes.
 #[cfg_attr(test, mockall::automock)]
 pub trait ProcessManager {

--- a/kernel_core/src/process/system_calls/mod.rs
+++ b/kernel_core/src/process/system_calls/mod.rs
@@ -5,8 +5,8 @@ use alloc::{string::String, sync::Arc, vec::Vec};
 use bytemuck::Contiguous;
 use kernel_api::{
     flags::{ExitNotificationSubscriptionFlags, FreeMessageFlags, ReceiveFlags},
-    CallNumber, EnvironmentValue, ErrorCode, ExitReason, Message, ProcessId,
-    QueueId, SharedBufferCreateInfo, ThreadCreateInfo, ThreadId,
+    CallNumber, EnvironmentValue, ErrorCode, ExitReason, Message, ProcessId, QueueId,
+    SharedBufferCreateInfo, ThreadCreateInfo, ThreadId,
 };
 use log::{debug, error, trace, warn};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};

--- a/kernel_core/src/process/system_calls/tests.rs
+++ b/kernel_core/src/process/system_calls/tests.rs
@@ -194,6 +194,7 @@ fn normal_spawn_thread() {
         entry: test_entry,
         stack_size: 100,
         user_data: 777,
+        notify_on_exit: None,
     };
     let info_ptr = &raw const info;
 
@@ -229,6 +230,89 @@ fn normal_spawn_thread() {
     );
 
     assert_eq!(thread_id, 9);
+}
+
+#[test]
+fn spawn_thread_and_subscribe_to_exit() {
+    fn test_entry(_: usize) -> ! {
+        unreachable!()
+    }
+
+    let pm = MockProcessManager::new();
+    let mut tm = MockThreadManager::new();
+    let mut qm = MockQueueManager::new();
+
+    let proc = crate::process::tests::create_test_process(
+        ProcessId::new(7).unwrap(),
+        crate::process::Properties {
+            supervisor_queue: None,
+            registry_queue: None,
+            privilege: kernel_api::PrivilegeLevel::Privileged,
+        },
+        ThreadId::new(8).unwrap(),
+    )
+    .unwrap();
+
+    let qid = QueueId::new(15).unwrap();
+    let qu = Arc::new(MessageQueue::new(qid, &proc));
+    qm.expect_queue_for_id()
+        .with(eq(qid))
+        .return_once(|_| Some(qu));
+
+    let new_thread = Arc::new(Thread::new(
+        ThreadId::new(9).unwrap(),
+        Some(proc.clone()),
+        State::Running,
+        ProcessorState::new_for_user_thread(VirtualAddress::null(), VirtualAddress::null(), 0),
+        (VirtualAddress::null(), 0),
+    ));
+    let new_thread2 = new_thread.clone();
+
+    let info = ThreadCreateInfo {
+        entry: test_entry,
+        stack_size: 100,
+        user_data: 777,
+        notify_on_exit: Some(qid),
+    };
+    let info_ptr = &raw const info;
+
+    let mut thread_id = 0;
+    let thread_id_ptr = &raw mut thread_id;
+
+    let pid = proc.id;
+    tm.expect_spawn_thread()
+        .with(
+            mockall::predicate::function(move |p: &Arc<Process>| p.id == pid),
+            eq(VirtualAddress::from(test_entry as usize)),
+            eq(info.stack_size),
+            eq(info.user_data),
+        )
+        .return_once(|_, _, _, _| Ok(new_thread));
+
+    let mut registers = Registers::default();
+    registers.x[0] = info_ptr as _;
+    registers.x[1] = thread_id_ptr as _;
+
+    let th = proc.threads.read().first().unwrap().clone();
+
+    let policy = SystemCalls::new(&*PAGE_ALLOCATOR, &pm, &tm, &qm);
+    let usm = AlwaysValidActiveUserSpaceTables::new(PAGE_ALLOCATOR.page_size());
+    assert_matches!(
+        policy.dispatch_system_call(
+            CallNumber::SpawnThread.into_integer(),
+            &th,
+            &registers,
+            &usm
+        ),
+        Ok(SysCallEffect::Return(0))
+    );
+
+    assert_eq!(thread_id, 9);
+    assert!(new_thread2
+        .exit_subscribers
+        .lock()
+        .iter()
+        .any(|q| q.id == qid));
 }
 
 #[test]
@@ -604,6 +688,112 @@ fn normal_spawn_process() {
     );
     assert_eq!(process_id, new_proc_id.get());
     assert_eq!(queue_id, new_queue_id.get());
+}
+
+#[test]
+fn spawn_process_and_subscribe_to_exit() {
+    let mut pm = MockProcessManager::new();
+    let mut tm = MockThreadManager::new();
+    let mut qm = MockQueueManager::new();
+    let parent_proc = crate::process::tests::create_test_process(
+        ProcessId::new(10).unwrap(),
+        Properties {
+            supervisor_queue: None,
+            registry_queue: None,
+            privilege: kernel_api::PrivilegeLevel::Privileged,
+        },
+        ThreadId::new(11).unwrap(),
+    )
+    .unwrap();
+
+    let qid = QueueId::new(15).unwrap();
+    let qu = Arc::new(MessageQueue::new(qid, &parent_proc));
+    qm.expect_queue_for_id()
+        .with(eq(qid))
+        .return_once(|_| Some(qu));
+
+    let dummy_info: ProcessCreateInfo = ProcessCreateInfo {
+        entry_point: 0,
+        num_sections: 0,
+        sections: core::ptr::null(),
+        supervisor: None,
+        registry: None,
+        privilege_level: kernel_api::PrivilegeLevel::Unprivileged,
+        notify_on_exit: Some(qid),
+        inbox_size: 0,
+    };
+    let info_ptr = &dummy_info as *const _;
+    let mut process_id: u32 = 0;
+    let process_id_ptr = &mut process_id as *mut u32;
+    let mut queue_id: u32 = 0;
+    let queue_id_ptr = &mut queue_id as *mut u32;
+
+    let parent_thread = parent_proc.threads.read().first().unwrap().clone();
+    // Create a new process that will be returned by spawn_process.
+    let new_proc_id = ProcessId::new(20).unwrap();
+    let new_proc = crate::process::tests::create_test_process(
+        new_proc_id,
+        Properties {
+            supervisor_queue: None,
+            registry_queue: None,
+            privilege: kernel_api::PrivilegeLevel::Privileged,
+        },
+        ThreadId::new(21).unwrap(),
+    )
+    .unwrap();
+
+    // Expect spawn_process to be called with the proper parent.
+    let parent_clone = parent_proc.clone();
+    let new_proc2 = new_proc.clone();
+    pm.expect_spawn_process()
+        .withf(move |p, _| p.as_ref().is_some_and(|p| p.id == parent_clone.id))
+        .return_once(move |_, _| Ok(new_proc2));
+
+    let new_queue_id = QueueId::new(34).unwrap();
+    qm.expect_create_queue()
+        .withf(move |o| o.id == new_proc_id)
+        .return_once(move |o| Ok(Arc::new(MessageQueue::new(new_queue_id, o))));
+
+    let new_thread_id = ThreadId::new(234).unwrap();
+    tm.expect_spawn_thread()
+        .with(
+            function(move |p: &Arc<Process>| p.id == new_proc_id),
+            eq(VirtualAddress::from(dummy_info.entry_point)),
+            eq(2048),
+            eq(new_queue_id.get() as usize),
+        )
+        .return_once(move |p, entry, stack_size, user_data| {
+            Ok(Arc::new(Thread::new(
+                new_thread_id,
+                Some(p),
+                State::Running,
+                ProcessorState::new_for_user_thread(entry, VirtualAddress::null(), user_data),
+                (VirtualAddress::null(), stack_size),
+            )))
+        });
+
+    let pa = &*PAGE_ALLOCATOR;
+    let policy = SystemCalls::new(pa, &pm, &tm, &qm);
+    let usm = AlwaysValidActiveUserSpaceTables::new(pa.page_size());
+
+    let mut registers = Registers::default();
+    registers.x[0] = info_ptr as usize;
+    registers.x[1] = process_id_ptr as usize;
+    registers.x[2] = queue_id_ptr as usize;
+
+    // The current thread (from parent_proc) is used so that its parent is set.
+    assert_matches!(
+        policy.dispatch_system_call(
+            CallNumber::SpawnProcess.into_integer(),
+            &parent_thread,
+            &registers,
+            &usm
+        ),
+        Ok(SysCallEffect::Return(0))
+    );
+    assert_eq!(process_id, new_proc_id.get());
+    assert_eq!(queue_id, new_queue_id.get());
+    assert!(new_proc.exit_subscribers.lock().iter().any(|q| q.id == qid));
 }
 
 #[test]

--- a/kernel_core/src/process/system_calls/tests.rs
+++ b/kernel_core/src/process/system_calls/tests.rs
@@ -530,7 +530,7 @@ fn normal_spawn_process() {
         supervisor: None,
         registry: None,
         privilege_level: kernel_api::PrivilegeLevel::Unprivileged,
-        notify_on_exit: false,
+        notify_on_exit: None,
         inbox_size: 0,
     };
     let info_ptr = &dummy_info as *const _;

--- a/services/egg/src/spawn.rs
+++ b/services/egg/src/spawn.rs
@@ -88,7 +88,7 @@ pub fn spawn_root_process(
         supervisor: Some(self_pid),
         registry: Some(self_pid),
         privilege_level: PrivilegeLevel::Driver,
-        notify_on_exit: false,
+        notify_on_exit: None,
         inbox_size: 256,
     };
 


### PR DESCRIPTION
Before you had to race the thing you spawned to subscribe to its exit before it exited. This is bad. Now you can do a spawn+subscribe atomically. 