### PR TITLE
Add process syscall tests

### DIFF
--- a/services/check-syscalls/src/main.rs
+++ b/services/check-syscalls/src/main.rs
@@ -30,8 +30,14 @@ where
 mod heap;
 mod read_env_value;
 mod threads;
+mod processes;
 
-const TESTS: &[(&str, &[&dyn Testable])] = &[read_env_value::TESTS, heap::TESTS, threads::TESTS];
+const TESTS: &[(&str, &[&dyn Testable])] = &[
+    read_env_value::TESTS,
+    heap::TESTS,
+    threads::TESTS,
+    processes::TESTS,
+];
 
 /// The main entry point.
 ///

--- a/services/check-syscalls/src/processes.rs
+++ b/services/check-syscalls/src/processes.rs
@@ -1,0 +1,223 @@
+//! Integration tests for process-related system calls.
+#![allow(clippy::cast_possible_truncation)]
+
+
+use bytemuck::cast_slice;
+use kernel_api::{
+    create_message_queue, free_message_queue, kill_process, read_env_value,
+    receive, spawn_process,
+    flags::{ExitNotificationSubscriptionFlags, FreeMessageFlags, ReceiveFlags},
+    ErrorCode, ExitMessage, ExitReasonTag, ExitSource, ImageSection, ImageSectionKind,
+    PrivilegeLevel, ProcessCreateInfo, ProcessId, QueueId,
+};
+
+use crate::Testable;
+
+/// Simple assembly functions used as process entry points.
+unsafe extern "C" fn proc_exit_success() -> ! {
+    unsafe {
+        core::arch::asm!(
+            "mov x0, #0",
+            "svc #0x107", // ExitCurrentThread
+            options(noreturn)
+        );
+    }
+}
+
+static PROC_MSG: [u8; 4] = *b"ping";
+
+unsafe extern "C" fn proc_send_and_exit() -> ! {
+    unsafe {
+        core::arch::asm!(
+            // x0 already holds the parent queue id
+            "adrp x1, {msg}",
+            "add x1, x1, :lo12:{msg}",
+            "mov x2, #4",
+            "mov x3, xzr",
+            "mov x4, xzr",
+            "svc #0x100", // Send
+            "mov x0, #0",
+            "svc #0x107", // ExitCurrentThread
+            msg = sym PROC_MSG,
+            options(noreturn)
+        );
+    }
+}
+
+unsafe extern "C" fn proc_spin() -> ! {
+    unsafe {
+        core::arch::asm!(
+            "1: b 1b",
+            options(noreturn)
+        );
+    }
+}
+
+/// Build a minimal [`ProcessCreateInfo`] using a single executable page copied
+/// from the current process.
+fn mk_proc_info(entry: unsafe extern "C" fn() -> !, notify: Option<QueueId>) -> (ProcessCreateInfo, [ImageSection; 1]) {
+    let page_size = read_env_value(kernel_api::EnvironmentValue::PageSizeInBytes);
+    let entry_addr = entry as usize;
+    let base = entry_addr & !(page_size - 1);
+    let section = [ImageSection {
+        base_address: base,
+        data_offset: 0,
+        total_size: page_size,
+        data_size: page_size,
+        data: base as *const u8,
+        kind: ImageSectionKind::Executable,
+    }];
+    (
+        ProcessCreateInfo {
+            entry_point: entry_addr,
+            num_sections: 1,
+            sections: section.as_ptr(),
+            supervisor: None,
+            registry: None,
+            privilege_level: PrivilegeLevel::Unprivileged,
+            notify_on_exit: notify,
+            inbox_size: 64,
+        },
+        section,
+    )
+}
+
+/// ---
+/// Successful spawn with exit notification.
+/// ---
+fn test_spawn_and_exit_notification() {
+    let qid = create_message_queue().expect("queue create");
+    let (info, _sections) = mk_proc_info(proc_exit_success, Some(qid));
+    let (pid, _child_qid) = spawn_process(&info).expect("spawn failed");
+
+    let msg = receive(ReceiveFlags::empty(), qid).expect("receive failed");
+    assert_eq!(msg.header().num_buffers, 0);
+    let exit_msg: &ExitMessage = cast_slice(msg.payload()).first().unwrap();
+    assert_eq!(exit_msg.source, ExitSource::Process);
+    assert_eq!(exit_msg.id, pid.get());
+    assert_eq!(exit_msg.reason.tag, ExitReasonTag::User);
+    assert_eq!(exit_msg.reason.user_code, 0);
+
+    msg.free(FreeMessageFlags::empty());
+    free_message_queue(qid).unwrap();
+}
+
+/// ---
+/// Spawn a process that sends a message then exits.
+/// ---
+fn test_spawn_send_message() {
+    let qid = create_message_queue().expect("queue create");
+    let (info, _sections) = mk_proc_info(proc_send_and_exit, Some(qid));
+    let (pid, _child_qid) = spawn_process(&info).expect("spawn failed");
+
+    let first = receive(ReceiveFlags::empty(), qid).expect("receive failed");
+    let second = receive(ReceiveFlags::empty(), qid).expect("receive failed");
+    let (msg_proc, msg_exit) = if first.payload().len() == PROC_MSG.len() {
+        (first, second)
+    } else {
+        (second, first)
+    };
+
+    assert_eq!(msg_proc.payload(), PROC_MSG);
+    msg_proc.free(FreeMessageFlags::empty());
+
+    let exit_msg: &ExitMessage = cast_slice(msg_exit.payload()).first().unwrap();
+    assert_eq!(exit_msg.source, ExitSource::Process);
+    assert_eq!(exit_msg.id, pid.get());
+    msg_exit.free(FreeMessageFlags::empty());
+    free_message_queue(qid).unwrap();
+}
+
+/// ---
+/// Spawn then kill a running process, expecting a killed exit reason.
+/// ---
+fn test_kill_process_notification() {
+    let qid = create_message_queue().expect("queue create");
+    let (info, _sections) = mk_proc_info(proc_spin, Some(qid));
+    let (pid, _child_qid) = spawn_process(&info).expect("spawn failed");
+
+    kill_process(pid).expect("kill failed");
+
+    let msg = receive(ReceiveFlags::empty(), qid).expect("receive failed");
+    let exit_msg: &ExitMessage = cast_slice(msg.payload()).first().unwrap();
+    assert_eq!(exit_msg.source, ExitSource::Process);
+    assert_eq!(exit_msg.id, pid.get());
+    assert_eq!(exit_msg.reason.tag, ExitReasonTag::Killed);
+
+    msg.free(FreeMessageFlags::empty());
+    free_message_queue(qid).unwrap();
+}
+
+/// ---
+/// Attempting to kill an unknown process must yield `NotFound`.
+/// ---
+fn test_kill_process_not_found() {
+    let fake_pid = ProcessId::new(0xDEAD_BEEFu32).unwrap();
+    match kill_process(fake_pid) {
+        Err(ErrorCode::NotFound) => {}
+        other => panic!("expected NotFound, got {:?}", other),
+    }
+}
+
+/// ---
+/// Invalid process image pointer ⇒ `InvalidPointer`.
+/// ---
+#[allow(invalid_value)]
+fn test_spawn_null_sections() {
+    let info = ProcessCreateInfo {
+        entry_point: 0,
+        num_sections: 1,
+        sections: core::ptr::null(),
+        supervisor: None,
+        registry: None,
+        privilege_level: PrivilegeLevel::Unprivileged,
+        notify_on_exit: None,
+        inbox_size: 0,
+    };
+    match spawn_process(&info) {
+        Err(ErrorCode::InvalidPointer) => {}
+        other => panic!("expected InvalidPointer, got {:?}", other),
+    }
+}
+
+/// ---
+/// Misaligned section base address ⇒ `BadFormat`.
+/// ---
+fn test_spawn_bad_format() {
+    let (mut info, mut sections) = mk_proc_info(proc_exit_success, None);
+    sections[0].base_address += 1; // not page aligned
+    info.sections = sections.as_ptr();
+    match spawn_process(&info) {
+        Err(ErrorCode::BadFormat) => {}
+        other => panic!("expected BadFormat, got {:?}", other),
+    }
+}
+
+/// ---
+/// Subscribe to a non-existent process ID ⇒ `NotFound`.
+/// ---
+fn test_exit_sub_unknown_process() {
+    let qid = create_message_queue().expect("queue create");
+    match kernel_api::exit_notification_subscription(
+        ExitNotificationSubscriptionFlags::PROCESS,
+        0xCAFEBABEu32,
+        qid,
+    ) {
+        Err(ErrorCode::NotFound) => {}
+        other => panic!("expected NotFound, got {:?}", other),
+    }
+    free_message_queue(qid).ok();
+}
+
+pub const TESTS: (&str, &[&dyn Testable]) = (
+    "processes",
+    &[
+        &test_spawn_and_exit_notification,
+        &test_spawn_send_message,
+        &test_kill_process_notification,
+        &test_kill_process_not_found,
+        &test_spawn_null_sections,
+        &test_spawn_bad_format,
+        &test_exit_sub_unknown_process,
+    ],
+);


### PR DESCRIPTION
## Summary
- add integration tests for process-related syscalls in check-syscalls service
- register new test module in the root test runner

## Testing
- `just build`

------
https://chatgpt.com/codex/tasks/task_e_6841a37f4e208328801b85849fb583d4