### PR TITLE
Add driver address region system calls

### DIFF
--- a/kernel_api/src/flags.rs
+++ b/kernel_api/src/flags.rs
@@ -13,6 +13,17 @@ bitflags! {
 }
 
 bitflags! {
+    /// Flags for the `driver_acquire_address_region()` system call.
+    #[derive(Debug, Clone, Copy)]
+    pub struct DriverAddressRegionFlags: usize {
+        /// Enables caching for the mapped region.
+        const ENABLE_CACHE = 0b01;
+        /// Map the region read-only.
+        const READ_ONLY = 0b10;
+    }
+}
+
+bitflags! {
     /// Flags that define the properties of a shared buffer.
     #[derive(Debug, Clone, Copy)]
     pub struct SharedBufferFlags: u32 {

--- a/kernel_api/src/lib.rs
+++ b/kernel_api/src/lib.rs
@@ -88,6 +88,8 @@ pub enum CallNumber {
     WriteLogMessage,
     CreateMessageQueue,
     FreeMessageQueue,
+    DriverAcquireAddressRegion,
+    DriverReleaseAddressRegion,
 }
 
 impl CallNumber {

--- a/kernel_core/src/process/system_calls/driver_acquire_address_region.rs
+++ b/kernel_core/src/process/system_calls/driver_acquire_address_region.rs
@@ -1,0 +1,227 @@
+use alloc::sync::Arc;
+
+use kernel_api::{flags::DriverAddressRegionFlags, PrivilegeLevel};
+use snafu::{ensure, OptionExt, ResultExt};
+
+use crate::{
+    memory::{
+        active_user_space_tables::{ActiveUserSpaceTables, ActiveUserSpaceTablesChecker},
+        page_table::{MemoryKind, MemoryProperties},
+        PageAllocator, PhysicalAddress,
+    },
+    process::{
+        queue::QueueManager,
+        system_calls::{
+            InvalidAddressSnafu, InvalidFlagsSnafu, InvalidLengthSnafu, ManagerSnafu,
+            NotPermittedSnafu,
+        },
+        thread::{Registers, ThreadManager},
+        ProcessManager, Thread,
+    },
+};
+
+use super::{Error, SystemCalls};
+
+impl<PA: PageAllocator, PM: ProcessManager, TM: ThreadManager, QM: QueueManager>
+    SystemCalls<'_, '_, PA, PM, TM, QM>
+{
+    #[allow(clippy::unused_self)]
+    pub(super) fn syscall_driver_acquire_address_region<AUST: ActiveUserSpaceTables>(
+        &self,
+        current_thread: &Arc<Thread>,
+        registers: &Registers,
+        user_space_memory: ActiveUserSpaceTablesChecker<'_, AUST>,
+    ) -> Result<(), Error> {
+        let proc = current_thread.parent.as_ref().unwrap();
+        ensure!(
+            proc.props.privilege == PrivilegeLevel::Driver,
+            NotPermittedSnafu {
+                reason: "caller is not a driver",
+            }
+        );
+
+        let base: PhysicalAddress = registers.x[0].into();
+        let size: usize = registers.x[1];
+        ensure!(
+            size > 0,
+            InvalidLengthSnafu {
+                reason: "zero size",
+                length: size
+            }
+        );
+
+        let out_ptr: &mut usize = user_space_memory
+            .check_mut_ref(registers.x[2].into())
+            .context(InvalidAddressSnafu { cause: "output" })?;
+
+        let flags =
+            DriverAddressRegionFlags::from_bits(registers.x[3]).context(InvalidFlagsSnafu {
+                reason: "invalid flag bits",
+                bits: registers.x[3],
+            })?;
+
+        let mut props = MemoryProperties {
+            user_space_access: true,
+            writable: !flags.contains(DriverAddressRegionFlags::READ_ONLY),
+            executable: false,
+            ..MemoryProperties::default()
+        };
+        props.kind = if flags.contains(DriverAddressRegionFlags::ENABLE_CACHE) {
+            MemoryKind::Normal
+        } else {
+            MemoryKind::Device
+        };
+
+        let va = proc
+            .map_driver_region(base, size, &props)
+            .context(ManagerSnafu)?;
+        *out_ptr = va.into();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytemuck::Contiguous;
+    use std::assert_matches::assert_matches;
+
+    use kernel_api::{CallNumber, ProcessId};
+
+    use crate::{
+        memory::{active_user_space_tables::AlwaysValidActiveUserSpaceTables, PageAllocator},
+        process::{
+            queue::MockQueueManager, system_calls::SysCallEffect, tests::PAGE_ALLOCATOR,
+            thread::MockThreadManager, MockProcessManager, Properties, ThreadId,
+        },
+    };
+
+    use super::*;
+
+    #[test]
+    fn acquire_success() {
+        let pa = &*PAGE_ALLOCATOR;
+        let proc = crate::process::tests::create_test_process(
+            ProcessId::new(600).unwrap(),
+            Properties {
+                supervisor_queue: None,
+                registry_queue: None,
+                privilege: PrivilegeLevel::Driver,
+            },
+            ThreadId::new(601).unwrap(),
+        )
+        .unwrap();
+        let current_thread = proc.threads.read().first().unwrap().clone();
+        let pm = MockProcessManager::new();
+        let tm = MockThreadManager::new();
+        let qm = MockQueueManager::new();
+        let policy = SystemCalls::new(pa, &pm, &tm, &qm);
+        let usm = AlwaysValidActiveUserSpaceTables::new(pa.page_size());
+
+        let phys = pa.allocate(1).unwrap();
+        let mut out: usize = 0;
+        let mut regs = Registers::default();
+        regs.x[0] = usize::from(phys);
+        regs.x[1] = 1;
+        regs.x[2] = (&mut out) as *mut usize as usize;
+        regs.x[3] = 0;
+
+        assert_matches!(
+            policy.dispatch_system_call(
+                CallNumber::DriverAcquireAddressRegion.into_integer(),
+                &current_thread,
+                &regs,
+                &usm
+            ),
+            Ok(SysCallEffect::Return(0))
+        );
+        assert_ne!(out, 0);
+        assert!(proc
+            .driver_mappings
+            .lock()
+            .iter()
+            .any(|(addr, _)| *addr == out.into()));
+
+        // cleanup
+        let _ = proc.unmap_driver_region(out.into());
+        pa.free(phys, 1).unwrap();
+    }
+
+    #[test]
+    fn acquire_invalid_pointer() {
+        let pa = &*PAGE_ALLOCATOR;
+        let proc = crate::process::tests::create_test_process(
+            ProcessId::new(610).unwrap(),
+            Properties {
+                supervisor_queue: None,
+                registry_queue: None,
+                privilege: PrivilegeLevel::Driver,
+            },
+            ThreadId::new(611).unwrap(),
+        )
+        .unwrap();
+        let current_thread = proc.threads.read().first().unwrap().clone();
+        let pm = MockProcessManager::new();
+        let tm = MockThreadManager::new();
+        let qm = MockQueueManager::new();
+        let policy = SystemCalls::new(pa, &pm, &tm, &qm);
+        let usm = AlwaysValidActiveUserSpaceTables::new(pa.page_size());
+
+        let phys = pa.allocate(1).unwrap();
+        let mut regs = Registers::default();
+        regs.x[0] = usize::from(phys);
+        regs.x[1] = 1;
+        regs.x[2] = 0; // invalid pointer
+        regs.x[3] = 0;
+
+        assert_matches!(
+            policy.dispatch_system_call(
+                CallNumber::DriverAcquireAddressRegion.into_integer(),
+                &current_thread,
+                &regs,
+                &usm
+            ),
+            Err(Error::InvalidAddress { .. })
+        );
+        pa.free(phys, 1).unwrap();
+    }
+
+    #[test]
+    fn acquire_not_driver() {
+        let pa = &*PAGE_ALLOCATOR;
+        let proc = crate::process::tests::create_test_process(
+            ProcessId::new(620).unwrap(),
+            Properties {
+                supervisor_queue: None,
+                registry_queue: None,
+                privilege: PrivilegeLevel::Privileged,
+            },
+            ThreadId::new(621).unwrap(),
+        )
+        .unwrap();
+        let current_thread = proc.threads.read().first().unwrap().clone();
+        let pm = MockProcessManager::new();
+        let tm = MockThreadManager::new();
+        let qm = MockQueueManager::new();
+        let policy = SystemCalls::new(pa, &pm, &tm, &qm);
+        let usm = AlwaysValidActiveUserSpaceTables::new(pa.page_size());
+
+        let phys = pa.allocate(1).unwrap();
+        let mut out: usize = 0;
+        let mut regs = Registers::default();
+        regs.x[0] = usize::from(phys);
+        regs.x[1] = 1;
+        regs.x[2] = (&mut out) as *mut usize as usize;
+        regs.x[3] = 0;
+
+        assert_matches!(
+            policy.dispatch_system_call(
+                CallNumber::DriverAcquireAddressRegion.into_integer(),
+                &current_thread,
+                &regs,
+                &usm
+            ),
+            Err(Error::NotPermitted { .. })
+        );
+        pa.free(phys, 1).unwrap();
+    }
+}

--- a/kernel_core/src/process/system_calls/driver_release_address_region.rs
+++ b/kernel_core/src/process/system_calls/driver_release_address_region.rs
@@ -1,0 +1,145 @@
+use alloc::sync::Arc;
+
+use kernel_api::PrivilegeLevel;
+use snafu::ensure;
+
+use crate::{
+    memory::{PageAllocator, VirtualAddress},
+    process::{
+        queue::QueueManager,
+        system_calls::NotPermittedSnafu,
+        thread::{Registers, ThreadManager},
+        ProcessManager, Thread,
+    },
+};
+
+use super::{Error, SystemCalls};
+
+impl<PA: PageAllocator, PM: ProcessManager, TM: ThreadManager, QM: QueueManager>
+    SystemCalls<'_, '_, PA, PM, TM, QM>
+{
+    #[allow(clippy::unused_self)]
+    pub(super) fn syscall_driver_release_address_region(
+        &self,
+        current_thread: &Arc<Thread>,
+        registers: &Registers,
+    ) -> Result<(), Error> {
+        let proc = current_thread.parent.as_ref().unwrap();
+        ensure!(
+            proc.props.privilege == PrivilegeLevel::Driver,
+            NotPermittedSnafu {
+                reason: "caller is not a driver",
+            }
+        );
+        let va: VirtualAddress = registers.x[0].into();
+        match proc.unmap_driver_region(va) {
+            Ok(()) => Ok(()),
+            Err(crate::process::ManagerError::Missing { .. }) => Err(Error::NotFound {
+                reason: "mapping not found".into(),
+                id: usize::from(va),
+            }),
+            Err(other) => Err(Error::Manager { source: other }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytemuck::Contiguous;
+    use std::assert_matches::assert_matches;
+
+    use kernel_api::{CallNumber, ProcessId};
+
+    use crate::{
+        memory::{active_user_space_tables::AlwaysValidActiveUserSpaceTables, PageAllocator},
+        process::{
+            queue::MockQueueManager, system_calls::SysCallEffect, tests::PAGE_ALLOCATOR,
+            thread::MockThreadManager, MockProcessManager, Properties, ThreadId,
+        },
+    };
+
+    use super::*;
+
+    #[test]
+    fn release_success() {
+        let pa = &*PAGE_ALLOCATOR;
+        let proc = crate::process::tests::create_test_process(
+            ProcessId::new(700).unwrap(),
+            Properties {
+                supervisor_queue: None,
+                registry_queue: None,
+                privilege: PrivilegeLevel::Driver,
+            },
+            ThreadId::new(701).unwrap(),
+        )
+        .unwrap();
+        let current_thread = proc.threads.read().first().unwrap().clone();
+        let pm = MockProcessManager::new();
+        let tm = MockThreadManager::new();
+        let qm = MockQueueManager::new();
+        let policy = SystemCalls::new(pa, &pm, &tm, &qm);
+        let usm = AlwaysValidActiveUserSpaceTables::new(pa.page_size());
+
+        let phys = pa.allocate(1).unwrap();
+        let mut out: usize = 0;
+        let mut regs = Registers::default();
+        regs.x[0] = usize::from(phys);
+        regs.x[1] = 1;
+        regs.x[2] = (&mut out) as *mut usize as usize;
+        regs.x[3] = 0;
+        assert_matches!(
+            policy.dispatch_system_call(
+                CallNumber::DriverAcquireAddressRegion.into_integer(),
+                &current_thread,
+                &regs,
+                &usm
+            ),
+            Ok(SysCallEffect::Return(0))
+        );
+        let mut regs = Registers::default();
+        regs.x[0] = out;
+        assert_matches!(
+            policy.dispatch_system_call(
+                CallNumber::DriverReleaseAddressRegion.into_integer(),
+                &current_thread,
+                &regs,
+                &usm
+            ),
+            Ok(SysCallEffect::Return(0))
+        );
+        pa.free(phys, 1).unwrap();
+    }
+
+    #[test]
+    fn release_not_found() {
+        let pa = &*PAGE_ALLOCATOR;
+        let proc = crate::process::tests::create_test_process(
+            ProcessId::new(710).unwrap(),
+            Properties {
+                supervisor_queue: None,
+                registry_queue: None,
+                privilege: PrivilegeLevel::Driver,
+            },
+            ThreadId::new(711).unwrap(),
+        )
+        .unwrap();
+        let current_thread = proc.threads.read().first().unwrap().clone();
+        let pm = MockProcessManager::new();
+        let tm = MockThreadManager::new();
+        let qm = MockQueueManager::new();
+        let policy = SystemCalls::new(pa, &pm, &tm, &qm);
+        let usm = AlwaysValidActiveUserSpaceTables::new(pa.page_size());
+
+        let mut regs = Registers::default();
+        regs.x[0] = 0xdeadbeef;
+        assert_matches!(
+            policy.dispatch_system_call(
+                CallNumber::DriverReleaseAddressRegion.into_integer(),
+                &current_thread,
+                &regs,
+                &usm
+            ),
+            Err(Error::NotFound { .. })
+        );
+    }
+}

--- a/kernel_core/src/process/system_calls/mod.rs
+++ b/kernel_core/src/process/system_calls/mod.rs
@@ -155,6 +155,8 @@ pub struct SystemCalls<
 // system call handler impl modules
 mod allocate_heap_pages;
 mod create_msg_queue;
+mod driver_acquire_address_region;
+mod driver_release_address_region;
 mod exit_current_thread;
 mod exit_notification_subscription;
 mod free_heap_pages;
@@ -299,6 +301,18 @@ impl<'pa, 'm, PA: PageAllocator, PM: ProcessManager, TM: ThreadManager, QM: Queu
             }
             CallNumber::FreeMessageQueue => {
                 self.syscall_free_msg_queue(registers)?;
+                Ok(SysCallEffect::Return(0))
+            }
+            CallNumber::DriverAcquireAddressRegion => {
+                self.syscall_driver_acquire_address_region(
+                    current_thread,
+                    registers,
+                    user_space_memory,
+                )?;
+                Ok(SysCallEffect::Return(0))
+            }
+            CallNumber::DriverReleaseAddressRegion => {
+                self.syscall_driver_release_address_region(current_thread, registers)?;
                 Ok(SysCallEffect::Return(0))
             }
         }


### PR DESCRIPTION
## Summary
- assign call numbers for driver address region operations
- expose flags and syscall wrappers in `kernel_api`
- track driver mappings in the process struct
- implement system call handlers to map and unmap driver regions
- include unit tests for the new system calls

## Testing
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_685a09c44bf88328a9d563d04d3a5c31