### PR TITLE
Fix confusing lifetime syntax and clippy lint

### DIFF
--- a/device_tree/src/iter.rs
+++ b/device_tree/src/iter.rs
@@ -7,12 +7,7 @@ use byteorder::{BigEndian, ByteOrder as _};
 use super::{Registers, Value, fdt};
 
 fn pad_end_4b(num_bytes: usize) -> usize {
-    num_bytes
-        + if num_bytes % 4 == 0 {
-            0
-        } else {
-            4 - (num_bytes % 4)
-        }
+    num_bytes.next_multiple_of(4)
 }
 
 /// Iterator over tree tokens in a device tree blob.

--- a/device_tree/src/lib.rs
+++ b/device_tree/src/lib.rs
@@ -37,7 +37,7 @@ impl StringList<'_> {
 
     /// Iterate over the strings present in the list as C strings.
     #[must_use]
-    pub fn iter(&self) -> iter::StringListIter {
+    pub fn iter(&self) -> iter::StringListIter<'_> {
         iter::StringListIter {
             data: self.data,
             current_offset: 0,
@@ -75,7 +75,7 @@ impl Registers<'_> {
     ///
     /// These are yielded as `usize`.
     #[must_use]
-    pub fn iter(&self) -> iter::RegistersIter {
+    pub fn iter(&self) -> iter::RegistersIter<'_, '_> {
         iter::RegistersIter {
             regs: self,
             offset: 0,
@@ -382,7 +382,7 @@ impl DeviceTree<'_> {
     /// - the magic value is incorrect.
     /// - the total length reported in the header does not match the length of the slice.
     #[must_use]
-    pub fn from_bytes(buf: &[u8]) -> DeviceTree {
+    pub fn from_bytes(buf: &[u8]) -> DeviceTree<'_> {
         let header = fdt::BlobHeader { buf };
         Self::from_bytes_and_header(buf, header)
     }
@@ -414,13 +414,13 @@ impl DeviceTree<'_> {
 
     /// Get the header for the blob.
     #[must_use]
-    pub fn header(&self) -> fdt::BlobHeader {
+    pub fn header(&self) -> fdt::BlobHeader<'_> {
         self.header
     }
 
     /// Iterate over the raw flattened tree blob structure.
     #[must_use]
-    pub fn iter_structure(&self) -> iter::FlattenedTreeIter {
+    pub fn iter_structure(&self) -> iter::FlattenedTreeIter<'_> {
         iter::FlattenedTreeIter {
             current_offset: 0,
             dt: self,
@@ -435,7 +435,7 @@ impl DeviceTree<'_> {
     /// # Returns
     /// An iterator over the properties of the node in the tree, if present.
     #[must_use]
-    pub fn iter_node_properties(&self, path: &[u8]) -> Option<iter::NodePropertyIter> {
+    pub fn iter_node_properties(&self, path: &[u8]) -> Option<iter::NodePropertyIter<'_>> {
         let mut segments = path.split(|p| *p == b'/');
         let mut looking_for = segments.next()?;
         let mut tokens = self.iter_structure();
@@ -546,7 +546,7 @@ impl DeviceTree<'_> {
     /// # Returns
     /// The value of the property if found.
     #[must_use]
-    pub fn find_property(&self, path: &[u8]) -> Option<Value> {
+    pub fn find_property(&self, path: &[u8]) -> Option<Value<'_>> {
         let split = path.iter().rev().find_position(|p| **p == b'/')?.0;
         let (node_path, property_name) = path.split_at(path.len() - split);
 
@@ -557,7 +557,7 @@ impl DeviceTree<'_> {
 
     /// Iterate over the system reserved memory regions.
     #[must_use]
-    pub fn iter_reserved_memory_regions(&self) -> iter::MemRegionIter {
+    pub fn iter_reserved_memory_regions(&self) -> iter::MemRegionIter<'_> {
         iter::MemRegionIter::for_data(self.mem_map)
     }
 }

--- a/kernel_core/src/memory/mod.rs
+++ b/kernel_core/src/memory/mod.rs
@@ -102,7 +102,7 @@ impl<T> PhysicalPointer<T> {
     #[inline]
     #[must_use]
     pub const fn is_aligned_to(self, alignment: usize) -> bool {
-        self.0 % alignment == 0
+        self.0.is_multiple_of(alignment)
     }
 }
 


### PR DESCRIPTION
## Summary
- remove manual code for 4 byte padding using `next_multiple_of`
- make iterator-returning methods use explicit lifetime elision
- expose lifetimes on DeviceTree APIs
- use `is_multiple_of` for pointer alignment

## Testing
- `just fmt`
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_68685b90e66c8328934ed1a0f42e9d31