### PR TITLE
Move flags to first arg for driver_acquire_address_region

### DIFF
--- a/device_tree/src/iter.rs
+++ b/device_tree/src/iter.rs
@@ -8,7 +8,7 @@ use super::{Registers, Value, fdt};
 
 fn pad_end_4b(num_bytes: usize) -> usize {
     num_bytes
-        + if num_bytes % 4 == 0 {
+        + if num_bytes.is_multiple_of(4) {
             0
         } else {
             4 - (num_bytes % 4)

--- a/kernel_api/src/wrappers.rs
+++ b/kernel_api/src/wrappers.rs
@@ -591,24 +591,24 @@ pub fn write_log(level: usize, msg: &str) -> Result<(), ErrorCode> {
 /// # Errors
 /// - `OutOfBounds`, `InUse`, `InvalidLength`, `InvalidFlags`, or `InvalidPointer` depending on the failure.
 pub fn driver_acquire_address_region(
+    flags: DriverAddressRegionFlags,
     base_address: usize,
     size: usize,
-    flags: DriverAddressRegionFlags,
 ) -> Result<*mut u8, ErrorCode> {
     let mut result: usize;
     let mut out = MaybeUninit::uninit();
     unsafe {
         asm!(
-            "mov x0, {b:x}",
-            "mov x1, {s:x}",
-            "mov x2, {p:x}",
-            "mov x3, {f:x}",
+            "mov x0, {f:x}",
+            "mov x1, {b:x}",
+            "mov x2, {s:x}",
+            "mov x3, {p:x}",
             "svc {call_number}",
             "mov {res}, x0",
+            f = in(reg) flags.bits(),
             b = in(reg) base_address,
             s = in(reg) size,
             p = in(reg) out.as_mut_ptr(),
-            f = in(reg) flags.bits(),
             res = out(reg) result,
             call_number = const CallNumber::DriverAcquireAddressRegion.into_num(),
         );

--- a/kernel_core/src/memory/mod.rs
+++ b/kernel_core/src/memory/mod.rs
@@ -102,7 +102,7 @@ impl<T> PhysicalPointer<T> {
     #[inline]
     #[must_use]
     pub const fn is_aligned_to(self, alignment: usize) -> bool {
-        self.0 % alignment == 0
+        self.0.is_multiple_of(alignment)
     }
 }
 

--- a/kernel_core/src/process/system_calls/driver_acquire_address_region.rs
+++ b/kernel_core/src/process/system_calls/driver_acquire_address_region.rs
@@ -40,8 +40,13 @@ impl<PA: PageAllocator, PM: ProcessManager, TM: ThreadManager, QM: QueueManager>
             }
         );
 
-        let base: PhysicalAddress = registers.x[0].into();
-        let size: usize = registers.x[1];
+        let flags =
+            DriverAddressRegionFlags::from_bits(registers.x[0]).context(InvalidFlagsSnafu {
+                reason: "invalid flag bits",
+                bits: registers.x[0],
+            })?;
+        let base: PhysicalAddress = registers.x[1].into();
+        let size: usize = registers.x[2];
         ensure!(
             size > 0,
             InvalidLengthSnafu {
@@ -75,14 +80,8 @@ impl<PA: PageAllocator, PM: ProcessManager, TM: ThreadManager, QM: QueueManager>
         );
 
         let out_ptr: &mut usize = user_space_memory
-            .check_mut_ref(registers.x[2].into())
+            .check_mut_ref(registers.x[3].into())
             .context(InvalidAddressSnafu { cause: "output" })?;
-
-        let flags =
-            DriverAddressRegionFlags::from_bits(registers.x[3]).context(InvalidFlagsSnafu {
-                reason: "invalid flag bits",
-                bits: registers.x[3],
-            })?;
 
         let mut props = MemoryProperties {
             user_space_access: true,
@@ -147,10 +146,10 @@ mod tests {
         };
         let mut out: usize = 0;
         let mut regs = Registers::default();
-        regs.x[0] = usize::from(phys);
-        regs.x[1] = 1;
-        regs.x[2] = (&mut out) as *mut usize as usize;
-        regs.x[3] = 0;
+        regs.x[0] = 0;
+        regs.x[1] = usize::from(phys);
+        regs.x[2] = 1;
+        regs.x[3] = (&mut out) as *mut usize as usize;
 
         assert_matches!(
             policy.dispatch_system_call(
@@ -194,10 +193,10 @@ mod tests {
 
         let phys = pa.allocate(1).unwrap();
         let mut regs = Registers::default();
-        regs.x[0] = usize::from(phys);
-        regs.x[1] = 1;
-        regs.x[2] = 0; // invalid pointer
-        regs.x[3] = 0;
+        regs.x[0] = 0;
+        regs.x[1] = usize::from(phys);
+        regs.x[2] = 1;
+        regs.x[3] = 0; // invalid pointer
 
         assert_matches!(
             policy.dispatch_system_call(
@@ -234,10 +233,10 @@ mod tests {
         let phys = PhysicalAddress::from(0x1000usize);
         let mut out = 0usize;
         let mut regs = Registers::default();
-        regs.x[0] = usize::from(phys);
-        regs.x[1] = 1;
-        regs.x[2] = (&mut out) as *mut usize as usize;
-        regs.x[3] = 0;
+        regs.x[0] = 0;
+        regs.x[1] = usize::from(phys);
+        regs.x[2] = 1;
+        regs.x[3] = (&mut out) as *mut usize as usize;
 
         assert_matches!(
             policy.dispatch_system_call(
@@ -273,10 +272,10 @@ mod tests {
         let phys = pa.allocate(1).unwrap();
         let mut out: usize = 0;
         let mut regs = Registers::default();
-        regs.x[0] = usize::from(phys);
-        regs.x[1] = 1;
-        regs.x[2] = (&mut out) as *mut usize as usize;
-        regs.x[3] = 0;
+        regs.x[0] = 0;
+        regs.x[1] = usize::from(phys);
+        regs.x[2] = 1;
+        regs.x[3] = (&mut out) as *mut usize as usize;
 
         assert_matches!(
             policy.dispatch_system_call(

--- a/kernel_core/src/process/system_calls/driver_release_address_region.rs
+++ b/kernel_core/src/process/system_calls/driver_release_address_region.rs
@@ -83,10 +83,10 @@ mod tests {
         let phys = pa.allocate(1).unwrap();
         let mut out: usize = 0;
         let mut regs = Registers::default();
-        regs.x[0] = usize::from(phys);
-        regs.x[1] = 1;
-        regs.x[2] = (&mut out) as *mut usize as usize;
-        regs.x[3] = 0;
+        regs.x[0] = 0;
+        regs.x[1] = usize::from(phys);
+        regs.x[2] = 1;
+        regs.x[3] = (&mut out) as *mut usize as usize;
         assert_matches!(
             policy.dispatch_system_call(
                 CallNumber::DriverAcquireAddressRegion.into_integer(),

--- a/spec/kernel.md
+++ b/spec/kernel.md
@@ -481,10 +481,10 @@ Only one driver can map any address at a time.
 #### Arguments
 | Name       | Type                 | Notes                            |
 |------------|----------------------|----------------------------------|
+| `flags`    | bitflag              | Options flags for this system call (see the `Flags` section). |
 | `base_address` | usize | The physical base address of the region. |
 | `size` | usize | The number of pages in the region. |
 | `dest_ptr` | `*mut *mut ()` | Pointer to location to write the virtual address of the region in the calling process' address space. |
-| `flags`    | bitflag              | Options flags for this system call (see the `Flags` section). |
 
 #### Flags
 The `driver_acquire_address_region` call accepts the following flags:
@@ -529,10 +529,10 @@ If the handler panics, then a message will be sent to the driver containing the 
 #### Arguments
 | Name       | Type                 | Notes                            |
 |------------|----------------------|----------------------------------|
+| `flags`    | bitflag              | Options flags for this system call (see the `Flags` section). |
 | `desc`     | `*const InterruptDesc` | Description of the interrupt to register for. |
 | `handler_pgrm` | `*const InterruptHandlerProgram` | The program to execute to handle an interrupt. |
 | `handler_id` | `*mut handler ID` | Returns the ID of the handler. |
-| `flags`    | bitflag              | Options flags for this system call (see the `Flags` section). |
 
 #### Flags
 The `driver_register_interrupt` call accepts the following flags:
@@ -560,8 +560,8 @@ Unregisters a previously registered interrupt handler. The handler will no longe
 #### Arguments
 | Name       | Type                 | Notes                            |
 |------------|----------------------|----------------------------------|
-| `handler_id` | handler ID | The ID of the handler returned from `driver_register_interrupt`. |
 | `flags`    | bitflag              | Options flags for this system call (see the `Flags` section). |
+| `handler_id` | handler ID | The ID of the handler returned from `driver_register_interrupt`. |
 
 #### Flags
 The `driver_unregister_interrupt` call accepts the following flags:


### PR DESCRIPTION
## Summary
- move flags parameter in `driver_acquire_address_region` to the first argument
- adjust wrapper implementation and kernel handler
- update tests and documentation
- fix clippy lint by using `is_multiple_of`

## Testing
- `just fmt`
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_68698676baf483289f7bf927508540db